### PR TITLE
Allow dependabot to check go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This change allows dependabot to check any go dependency which with project uses on a weekly basis and submit pull requests automatically with version bumps in order to keep packages up-to-date.

https://docs.github.com/en/github/administering-a-repository/keeping-your-dependencies-updated-automatically