### PR TITLE
fix regex for ruleset.metric_name, metric names can indeed have space…

### DIFF
--- a/circonus/resource_circonus_rule_set.go
+++ b/circonus/resource_circonus_rule_set.go
@@ -360,7 +360,7 @@ func resourceRuleSet() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateRegexp(ruleSetMetricNameAttr, `^[\S]+$`),
+				ValidateFunc: validateRegexp(ruleSetMetricNameAttr, `^.+$`),
 			},
 			ruleSetMetricPatternAttr: {
 				Type:         schema.TypeString,


### PR DESCRIPTION
…s in them