### PR TITLE
CIRC-7240: Make acceptance tests configurable for other environments

### DIFF
--- a/circonus/data_source_circonus_account_test.go
+++ b/circonus/data_source_circonus_account_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceCirconusAccount(t *testing.T) {
 			{
 				Config: testAccDataSourceCirconusAccountCurrentConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceCirconusAccountCheck("data.circonus_account.by_current", "/account/4536"),
+					testAccDataSourceCirconusAccountCheck("data.circonus_account.by_current", testAccAccount),
 				),
 			},
 		},
@@ -27,9 +27,11 @@ func TestAccDataSourceCirconusAccount(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceCirconusAccountIDConfig,
+				Config: fmt.Sprintf(testAccDataSourceCirconusAccountIDConfig,
+					testAccAccount,
+				),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceCirconusAccountCheck("data.circonus_account.by_id", "/account/4536"),
+					testAccDataSourceCirconusAccountCheck("data.circonus_account.by_id", testAccAccount),
 				),
 			},
 		},
@@ -61,6 +63,6 @@ data "circonus_account" "by_current" {
 
 const testAccDataSourceCirconusAccountIDConfig = `
 data "circonus_account" "by_id" {
-  id = "/account/4536"
+  id = "%s"
 }
 `

--- a/circonus/data_source_circonus_collector_test.go
+++ b/circonus/data_source_circonus_collector_test.go
@@ -14,9 +14,11 @@ func TestAccDataSourceCirconusCollector(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceCirconusCollectorConfig,
+				Config: fmt.Sprintf(testAccDataSourceCirconusCollectorConfig,
+					testAccBroker1,
+				),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceCirconusCollectorCheck("data.circonus_collector.by_id", "/broker/1"),
+					testAccDataSourceCirconusCollectorCheck("data.circonus_collector.by_id", testAccBroker1),
 				),
 			},
 		},
@@ -42,6 +44,6 @@ func testAccDataSourceCirconusCollectorCheck(name, cid string) resource.TestChec
 
 const testAccDataSourceCirconusCollectorConfig = `
 data "circonus_collector" "by_id" {
-  id = "/broker/1"
+  id = "%s"
 }
 `

--- a/circonus/provider_test.go
+++ b/circonus/provider_test.go
@@ -10,6 +10,17 @@ import (
 var (
 	testAccProviders map[string]*schema.Provider
 	testAccProvider  *schema.Provider
+
+	testAccAccount string
+
+	testAccBroker1 string
+	testAccBroker2 string
+	testAccBroker3 string
+	testAccBroker4 string
+
+	testAccContactGroup1 string
+	testAccContactGroup2 string
+	testAccContactGroup3 string
 )
 
 func init() {
@@ -17,6 +28,39 @@ func init() {
 	testAccProviders = map[string]*schema.Provider{
 		"circonus": testAccProvider,
 	}
+
+	if testAccAccount = os.Getenv("CIRCONUS_TEST_ACCOUNT"); testAccAccount == "" {
+		testAccAccount = "/account/4536"
+	}
+
+	if testAccBroker1 = os.Getenv("CIRCONUS_TEST_BROKER_1"); testAccBroker1 == "" {
+		testAccBroker1 = "/broker/1"
+	}
+
+	if testAccBroker2 = os.Getenv("CIRCONUS_TEST_BROKER_2"); testAccBroker2 == "" {
+		testAccBroker2 = "/broker/275"
+	}
+
+	if testAccBroker3 = os.Getenv("CIRCONUS_TEST_BROKER_3"); testAccBroker3 == "" {
+		testAccBroker3 = "/broker/35"
+	}
+
+	if testAccBroker4 = os.Getenv("CIRCONUS_TEST_BROKER_4"); testAccBroker4 == "" {
+		testAccBroker4 = "/broker/1490"
+	}
+
+	if testAccContactGroup1 = os.Getenv("CIRCONUS_TEST_CONTACT_GROUP_1"); testAccContactGroup1 == "" {
+		testAccContactGroup1 = "/contact_group/4661"
+	}
+
+	if testAccContactGroup2 = os.Getenv("CIRCONUS_TEST_CONTACT_GROUP_2"); testAccContactGroup2 == "" {
+		testAccContactGroup2 = "/contact_group/4679"
+	}
+
+	if testAccContactGroup3 = os.Getenv("CIRCONUS_TEST_CONTACT_GROUP_3"); testAccContactGroup3 == "" {
+		testAccContactGroup3 = "/contact_group/4680"
+	}
+
 }
 
 func TestProvider(t *testing.T) {

--- a/circonus/resource_circonus_check_caql_test.go
+++ b/circonus/resource_circonus_check_caql_test.go
@@ -16,11 +16,14 @@ func TestAccCirconusCheckCAQL_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(string(testAccCirconusCheckCAQLConfigFmt), checkName),
+				Config: fmt.Sprintf(string(testAccCirconusCheckCAQLConfigFmt),
+					checkName,
+					testAccBroker4,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.go_gc_latency", "active", "true"),
 					resource.TestCheckResourceAttr("circonus_check.go_gc_latency", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.go_gc_latency", "collector.0.id", "/broker/1490"),
+					resource.TestCheckResourceAttr("circonus_check.go_gc_latency", "collector.0.id", testAccBroker4),
 					resource.TestCheckResourceAttr("circonus_check.go_gc_latency", "caql.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.go_gc_latency", "caql.0.query", `search:metric:histogram("*consul*runtime`+"`"+`gc_pause_ns* (active:1)") | histogram:merge() | histogram:percentile(99)`+"\n"),
 					resource.TestCheckResourceAttr("circonus_check.go_gc_latency", "name", checkName),
@@ -52,7 +55,7 @@ resource "circonus_check" "go_gc_latency" {
   period = "60s"
 
   collector {
-    id = "/broker/1490"
+    id = "%s"
   }
 
   caql {

--- a/circonus/resource_circonus_check_cloudwatch_test.go
+++ b/circonus/resource_circonus_check_cloudwatch_test.go
@@ -29,11 +29,14 @@ func TestAccCirconusCheckCloudWatch_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckCloudWatchConfigFmt, checkName),
+				Config: fmt.Sprintf(testAccCirconusCheckCloudWatchConfigFmt,
+					checkName,
+					testAccBroker1,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.rds_metrics", "active", "true"),
 					resource.TestCheckResourceAttr("circonus_check.rds_metrics", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.rds_metrics", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.rds_metrics", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.rds_metrics", "cloudwatch.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.rds_metrics", "cloudwatch.0.dimmensions.%", "1"),
 					resource.TestCheckResourceAttr("circonus_check.rds_metrics", "cloudwatch.0.dimmensions.DBInstanceIdentifier", "atlas-production"),
@@ -145,7 +148,7 @@ resource "circonus_check" "rds_metrics" {
   period = "60s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   target = "atlas-production.us-east-1.rds._aws"

--- a/circonus/resource_circonus_check_dns_test.go
+++ b/circonus/resource_circonus_check_dns_test.go
@@ -19,7 +19,11 @@ func TestAccCirconusCheckDNS_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckDNSConfigFmt, checkName),
+				Config: fmt.Sprintf(testAccCirconusCheckDNSConfigFmt,
+					checkName,
+					testAccBroker1,
+					testAccBroker2,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.google", "active", "true"),
 					resource.TestCheckNoResourceAttr("circonus_check.google", "check_id"),
@@ -29,7 +33,7 @@ func TestAccCirconusCheckDNS_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("circonus_check.google", "check_id"),
 					resource.TestCheckResourceAttr("circonus_check.google", "check_by_collector.%", "2"),
 					resource.TestCheckResourceAttr("circonus_check.google", "collector.#", "2"),
-					resource.TestCheckResourceAttr("circonus_check.google", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.google", "collector.0.id", testAccBroker2),
 					resource.TestCheckResourceAttr("circonus_check.google", "dns.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.google", "name", checkName),
 					resource.TestCheckResourceAttr("circonus_check.google", "period", "300s"),
@@ -54,11 +58,11 @@ resource "circonus_check" "google" {
   period = "300s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   collector {
-    id = "/broker/275"
+    id = "%s"
   }
 
   dns {

--- a/circonus/resource_circonus_check_dns_test.go
+++ b/circonus/resource_circonus_check_dns_test.go
@@ -33,7 +33,7 @@ func TestAccCirconusCheckDNS_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("circonus_check.google", "check_id"),
 					resource.TestCheckResourceAttr("circonus_check.google", "check_by_collector.%", "2"),
 					resource.TestCheckResourceAttr("circonus_check.google", "collector.#", "2"),
-					resource.TestCheckResourceAttr("circonus_check.google", "collector.0.id", testAccBroker2),
+					resource.TestCheckResourceAttr("circonus_check.google", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.google", "dns.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.google", "name", checkName),
 					resource.TestCheckResourceAttr("circonus_check.google", "period", "300s"),

--- a/circonus/resource_circonus_check_http_test.go
+++ b/circonus/resource_circonus_check_http_test.go
@@ -17,11 +17,15 @@ func TestAccCirconusCheckHTTP_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckHTTPConfigFmt, checkName, 2),
+				Config: fmt.Sprintf(testAccCirconusCheckHTTPConfigFmt,
+					checkName,
+					testAccBroker1,
+					2,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.jezebel", "active", "true"),
 					resource.TestCheckResourceAttr("circonus_check.jezebel", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.jezebel", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.jezebel", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.jezebel", "http.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.jezebel", "http.0.code", `^200$`),
 					resource.TestCheckResourceAttr("circonus_check.jezebel", "http.0.extract", `HTTP/1.1 200 OK`),
@@ -63,11 +67,15 @@ func TestAccCirconusCheckHTTP_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckHTTPConfigFmt, checkName, 0),
+				Config: fmt.Sprintf(testAccCirconusCheckHTTPConfigFmt,
+					checkName,
+					testAccBroker1,
+					0,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.jezebel", "active", "true"),
 					resource.TestCheckResourceAttr("circonus_check.jezebel", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.jezebel", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.jezebel", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.jezebel", "http.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.jezebel", "http.0.code", `^200$`),
 					resource.TestCheckResourceAttr("circonus_check.jezebel", "http.0.extract", `HTTP/1.1 200 OK`),
@@ -145,7 +153,7 @@ resource "circonus_check" "jezebel" {
   period = "60s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   http {

--- a/circonus/resource_circonus_check_httptrap_test.go
+++ b/circonus/resource_circonus_check_httptrap_test.go
@@ -17,11 +17,14 @@ func TestAccCirconusCheckHTTPTrap_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckHTTPTrapConfigFmt, checkName),
+				Config: fmt.Sprintf(testAccCirconusCheckHTTPTrapConfigFmt,
+					checkName,
+					testAccBroker3,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.consul", "active", "true"),
 					resource.TestCheckResourceAttr("circonus_check.consul", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.consul", "collector.0.id", "/broker/35"),
+					resource.TestCheckResourceAttr("circonus_check.consul", "collector.0.id", testAccBroker3),
 					resource.TestCheckResourceAttr("circonus_check.consul", "httptrap.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.consul", "httptrap.0.async_metrics", "false"),
 					resource.TestCheckResourceAttr("circonus_check.consul", "httptrap.0.secret", "12345"),
@@ -72,7 +75,7 @@ resource "circonus_check" "consul" {
   period = "60s"
 
   collector {
-    id = "/broker/35"
+    id = "%s"
   }
 
   httptrap {

--- a/circonus/resource_circonus_check_icmp_ping_test.go
+++ b/circonus/resource_circonus_check_icmp_ping_test.go
@@ -19,7 +19,11 @@ func TestAccCirconusCheckICMPPing_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckICMPPingConfigFmt, checkName),
+				Config: fmt.Sprintf(testAccCirconusCheckICMPPingConfigFmt,
+					checkName,
+					testAccBroker1,
+					testAccBroker2,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "active", "true"),
 					resource.TestCheckNoResourceAttr("circonus_check.loopback_latency", "check_id"),
@@ -29,7 +33,7 @@ func TestAccCirconusCheckICMPPing_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("circonus_check.loopback_latency", "check_id"),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "check_by_collector.%", "2"),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "collector.#", "2"),
-					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "collector.0.id", testAccBroker2),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "icmp_ping.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "icmp_ping.0.availability", "100"),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "icmp_ping.0.count", "5"),
@@ -75,11 +79,11 @@ resource "circonus_check" "loopback_latency" {
   period = "300s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   collector {
-    id = "/broker/275"
+    id = "%s"
   }
 
   icmp_ping {

--- a/circonus/resource_circonus_check_icmp_ping_test.go
+++ b/circonus/resource_circonus_check_icmp_ping_test.go
@@ -33,7 +33,7 @@ func TestAccCirconusCheckICMPPing_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("circonus_check.loopback_latency", "check_id"),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "check_by_collector.%", "2"),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "collector.#", "2"),
-					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "collector.0.id", testAccBroker2),
+					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "icmp_ping.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "icmp_ping.0.availability", "100"),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "icmp_ping.0.count", "5"),

--- a/circonus/resource_circonus_check_jmx_test.go
+++ b/circonus/resource_circonus_check_jmx_test.go
@@ -29,7 +29,7 @@ func TestAccCirconusCheckJMX_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.something", "active", "true"),
 					resource.TestCheckResourceAttr("circonus_check.something", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.something", "collector.1893401625.id", "/broker/1286"),
+					resource.TestCheckResourceAttr("circonus_check.something", "collector.1893401625.id", accEnterpriseBrokerCID),
 					resource.TestCheckResourceAttr("circonus_check.something", "jmx.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.something", "jmx.453641246.host", "127.0.0.1"),
 					resource.TestCheckResourceAttr("circonus_check.something", "jmx.453641246.port", "9999"),

--- a/circonus/resource_circonus_check_json_test.go
+++ b/circonus/resource_circonus_check_json_test.go
@@ -1,6 +1,7 @@
 package circonus
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -15,12 +16,12 @@ func TestAccCirconusCheckJSON_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCirconusCheckJSONConfig1,
+				Config: fmt.Sprintf(testAccCirconusCheckJSONConfig1, testAccBroker1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.usage", "active", "true"),
 					resource.TestMatchResourceAttr("circonus_check.usage", "check_id", regexp.MustCompile(config.CheckCIDRegex)),
 					resource.TestCheckResourceAttr("circonus_check.usage", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.usage", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.usage", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.usage", "json.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.usage", "json.0.headers.%", "3"),
 					resource.TestCheckResourceAttr("circonus_check.usage", "json.0.headers.Accept", "application/json"),
@@ -47,11 +48,11 @@ func TestAccCirconusCheckJSON_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCirconusCheckJSONConfig2,
+				Config: fmt.Sprintf(testAccCirconusCheckJSONConfig2, testAccBroker1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.usage", "active", "true"),
 					resource.TestCheckResourceAttr("circonus_check.usage", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.usage", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.usage", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.usage", "json.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.usage", "json.0.headers.%", "3"),
 					resource.TestCheckResourceAttr("circonus_check.usage", "json.0.headers.Accept", "application/json"),
@@ -99,7 +100,7 @@ resource "circonus_check" "usage" {
   period = "60s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   json {
@@ -148,7 +149,7 @@ resource "circonus_check" "usage" {
   period = "300s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   json {

--- a/circonus/resource_circonus_check_metric_filter_test.go
+++ b/circonus/resource_circonus_check_metric_filter_test.go
@@ -20,7 +20,12 @@ func TestAccCirconusCheckMetricFilter_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckMetricFilterConfigFmt, checkName, target),
+				Config: fmt.Sprintf(testAccCirconusCheckMetricFilterConfigFmt,
+					checkName,
+					testAccBroker1,
+					testAccBroker2,
+					target,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.metric_filter", "active", "true"),
 					resource.TestCheckNoResourceAttr("circonus_check.metric_filter", "check_id"),
@@ -30,7 +35,7 @@ func TestAccCirconusCheckMetricFilter_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("circonus_check.metric_filter", "check_id"),
 					resource.TestCheckResourceAttr("circonus_check.metric_filter", "check_by_collector.%", "2"),
 					resource.TestCheckResourceAttr("circonus_check.metric_filter", "collector.#", "2"),
-					resource.TestCheckResourceAttr("circonus_check.metric_filter", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.metric_filter", "collector.0.id", testAccBroker2),
 					resource.TestCheckResourceAttr("circonus_check.metric_filter", "icmp_ping.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.metric_filter", "icmp_ping.0.availability", "100"),
 					resource.TestCheckResourceAttr("circonus_check.metric_filter", "icmp_ping.0.count", "5"),
@@ -68,11 +73,11 @@ resource "circonus_check" "metric_filter" {
   period = "300s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   collector {
-    id = "/broker/275"
+    id = "%s"
   }
 
   icmp_ping {

--- a/circonus/resource_circonus_check_metric_filter_test.go
+++ b/circonus/resource_circonus_check_metric_filter_test.go
@@ -35,7 +35,7 @@ func TestAccCirconusCheckMetricFilter_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("circonus_check.metric_filter", "check_id"),
 					resource.TestCheckResourceAttr("circonus_check.metric_filter", "check_by_collector.%", "2"),
 					resource.TestCheckResourceAttr("circonus_check.metric_filter", "collector.#", "2"),
-					resource.TestCheckResourceAttr("circonus_check.metric_filter", "collector.0.id", testAccBroker2),
+					resource.TestCheckResourceAttr("circonus_check.metric_filter", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.metric_filter", "icmp_ping.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.metric_filter", "icmp_ping.0.availability", "100"),
 					resource.TestCheckResourceAttr("circonus_check.metric_filter", "icmp_ping.0.count", "5"),

--- a/circonus/resource_circonus_check_mysql_test.go
+++ b/circonus/resource_circonus_check_mysql_test.go
@@ -17,11 +17,14 @@ func TestAccCirconusCheckMySQL_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckMySQLConfigFmt, checkName),
+				Config: fmt.Sprintf(testAccCirconusCheckMySQLConfigFmt,
+					checkName,
+					testAccBroker1,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.table_ops", "active", "true"),
 					resource.TestCheckResourceAttr("circonus_check.table_ops", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.table_ops", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.table_ops", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.table_ops", "mysql.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.table_ops", "mysql.0.dsn", "user=mysql host=mydb1.example.org port=3306 password=12345 sslmode=require"),
 					resource.TestCheckResourceAttr("circonus_check.table_ops", "mysql.0.query", `select 'binlog', total from (select variable_value as total from information_schema.global_status where variable_name='BINLOG_CACHE_USE') total`),
@@ -55,7 +58,7 @@ resource "circonus_check" "table_ops" {
   period = "300s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   mysql {

--- a/circonus/resource_circonus_check_ntp_test.go
+++ b/circonus/resource_circonus_check_ntp_test.go
@@ -33,7 +33,7 @@ func TestAccCirconusCheckNTP_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("circonus_check.clock", "check_id"),
 					resource.TestCheckResourceAttr("circonus_check.clock", "check_by_collector.%", "2"),
 					resource.TestCheckResourceAttr("circonus_check.clock", "collector.#", "2"),
-					resource.TestCheckResourceAttr("circonus_check.clock", "collector.0.id", testAccBroker2),
+					resource.TestCheckResourceAttr("circonus_check.clock", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.clock", "ntp.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.clock", "name", checkName),
 					resource.TestCheckResourceAttr("circonus_check.clock", "period", "300s"),

--- a/circonus/resource_circonus_check_ntp_test.go
+++ b/circonus/resource_circonus_check_ntp_test.go
@@ -19,7 +19,11 @@ func TestAccCirconusCheckNTP_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckNTPConfigFmt, checkName),
+				Config: fmt.Sprintf(testAccCirconusCheckNTPConfigFmt,
+					checkName,
+					testAccBroker1,
+					testAccBroker2,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.clock", "active", "true"),
 					resource.TestCheckNoResourceAttr("circonus_check.clock", "check_id"),
@@ -29,7 +33,7 @@ func TestAccCirconusCheckNTP_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr("circonus_check.clock", "check_id"),
 					resource.TestCheckResourceAttr("circonus_check.clock", "check_by_collector.%", "2"),
 					resource.TestCheckResourceAttr("circonus_check.clock", "collector.#", "2"),
-					resource.TestCheckResourceAttr("circonus_check.clock", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.clock", "collector.0.id", testAccBroker2),
 					resource.TestCheckResourceAttr("circonus_check.clock", "ntp.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.clock", "name", checkName),
 					resource.TestCheckResourceAttr("circonus_check.clock", "period", "300s"),
@@ -54,11 +58,11 @@ resource "circonus_check" "clock" {
   period = "300s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   collector {
-    id = "/broker/275"
+    id = "%s"
   }
 
   ntp {

--- a/circonus/resource_circonus_check_postgresql_test.go
+++ b/circonus/resource_circonus_check_postgresql_test.go
@@ -17,11 +17,14 @@ func TestAccCirconusCheckPostgreSQL_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckPostgreSQLConfigFmt, checkName),
+				Config: fmt.Sprintf(testAccCirconusCheckPostgreSQLConfigFmt,
+					checkName,
+					testAccBroker1,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.table_ops", "active", "true"),
 					resource.TestCheckResourceAttr("circonus_check.table_ops", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.table_ops", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.table_ops", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.table_ops", "postgresql.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.table_ops", "postgresql.0.dsn", "user=postgres host=pg1.example.org port=5432 password=12345 sslmode=require"),
 					resource.TestCheckResourceAttr("circonus_check.table_ops", "postgresql.0.query", `SELECT 'tables', sum(n_tup_ins) as inserts, sum(n_tup_upd) as updates, sum(n_tup_del) as deletes, sum(idx_scan)  as index_scans, sum(seq_scan) as seq_scans, sum(idx_tup_fetch) as index_tup_fetch, sum(seq_tup_read) as seq_tup_read from pg_stat_all_tables`),
@@ -72,7 +75,7 @@ resource "circonus_check" "table_ops" {
   period = "300s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   postgresql {

--- a/circonus/resource_circonus_check_redis_test.go
+++ b/circonus/resource_circonus_check_redis_test.go
@@ -17,11 +17,14 @@ func TestAccCirconusCheckRedis_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckRedisConfigFmt, checkName),
+				Config: fmt.Sprintf(testAccCirconusCheckRedisConfigFmt,
+					checkName,
+					testAccBroker1,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.redis", "active", "true"),
 					resource.TestCheckResourceAttr("circonus_check.redis", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.redis", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.redis", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.redis", "redis.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.redis", "name", checkName),
 					resource.TestCheckResourceAttr("circonus_check.redis", "notes", "Check to grab redis metrics"),
@@ -50,7 +53,7 @@ resource "circonus_check" "redis" {
   target = "127.0.0.1"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   redis {

--- a/circonus/resource_circonus_check_smtp_test.go
+++ b/circonus/resource_circonus_check_smtp_test.go
@@ -19,12 +19,15 @@ func TestAccCirconusCheckSMTP_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckSMTPConfigFmt, checkName),
+				Config: fmt.Sprintf(testAccCirconusCheckSMTPConfigFmt,
+					checkName,
+					testAccBroker1,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.smtp", "active", "true"),
 					resource.TestMatchResourceAttr("circonus_check.smtp", "check_id", regexp.MustCompile(config.CheckCIDRegex)),
 					resource.TestCheckResourceAttr("circonus_check.smtp", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.smtp", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.smtp", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.smtp", "name", checkName),
 					resource.TestCheckResourceAttr("circonus_check.smtp", "period", "300s"),
 					resource.TestCheckResourceAttr("circonus_check.smtp", "metric.#", "3"),
@@ -48,7 +51,7 @@ resource "circonus_check" "smtp" {
   period = "300s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   smtp {

--- a/circonus/resource_circonus_check_snmp_test.go
+++ b/circonus/resource_circonus_check_snmp_test.go
@@ -19,12 +19,12 @@ func TestAccCirconusCheckSNMP_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckSNMPConfigFmt, checkName),
+				Config: fmt.Sprintf(testAccCirconusCheckSNMPConfigFmt, checkName, testAccBroker1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.snmp", "active", "true"),
 					resource.TestMatchResourceAttr("circonus_check.snmp", "check_id", regexp.MustCompile(config.CheckCIDRegex)),
 					resource.TestCheckResourceAttr("circonus_check.snmp", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.snmp", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.snmp", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.snmp", "name", checkName),
 					resource.TestCheckResourceAttr("circonus_check.snmp", "period", "300s"),
 					resource.TestCheckResourceAttr("circonus_check.snmp", "metric.#", "3"),
@@ -56,7 +56,7 @@ resource "circonus_check" "snmp" {
   period = "300s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   snmp {

--- a/circonus/resource_circonus_check_tcp_test.go
+++ b/circonus/resource_circonus_check_tcp_test.go
@@ -17,11 +17,14 @@ func TestAccCirconusCheckTCP_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusCheckBundle,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusCheckTCPConfigFmt, checkName),
+				Config: fmt.Sprintf(testAccCirconusCheckTCPConfigFmt,
+					checkName,
+					testAccBroker1,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.tls_cert", "active", "true"),
 					resource.TestCheckResourceAttr("circonus_check.tls_cert", "collector.#", "1"),
-					resource.TestCheckResourceAttr("circonus_check.tls_cert", "collector.0.id", "/broker/1"),
+					resource.TestCheckResourceAttr("circonus_check.tls_cert", "collector.0.id", testAccBroker1),
 					resource.TestCheckResourceAttr("circonus_check.tls_cert", "tcp.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.tls_cert", "tcp.0.host", "127.0.0.1"),
 					resource.TestCheckResourceAttr("circonus_check.tls_cert", "tcp.0.port", "443"),
@@ -92,7 +95,7 @@ resource "circonus_check" "tls_cert" {
   period = "60s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   tcp {

--- a/circonus/resource_circonus_contact_test.go
+++ b/circonus/resource_circonus_contact_test.go
@@ -17,7 +17,13 @@ func TestAccCirconusContactGroup_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusContactGroup,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCirconusContactGroupConfig,
+				Config: fmt.Sprintf(testAccCirconusContactGroupConfig,
+					testAccContactGroup1,
+					testAccContactGroup1,
+					testAccContactGroup1,
+					testAccContactGroup1,
+					testAccContactGroup1,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					// testAccContactGroupExists("circonus_contact_group.staging-sev3", "foo"),
 					resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "name", "ops-staging-sev3"),
@@ -62,23 +68,23 @@ func TestAccCirconusContactGroup_basic(t *testing.T) {
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.689365425.severity", "1"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.689365425.reminder", "60s"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.689365425.escalate_after", "3600s"),
-					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.689365425.escalate_to", "/contact_group/4661"),
+					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.689365425.escalate_to", testAccContactGroup1),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.551050940.severity", "2"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.551050940.reminder", "120s"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.551050940.escalate_after", "7200s"),
-					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.551050940.escalate_to", "/contact_group/4661"),
+					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.551050940.escalate_to", testAccContactGroup1),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.1292974544.severity", "3"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.1292974544.reminder", "180s"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.1292974544.escalate_after", "10800s"),
-					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.1292974544.escalate_to", "/contact_group/4661"),
+					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.1292974544.escalate_to", testAccContactGroup1),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.1183354841.severity", "4"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.1183354841.reminder", "240s"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.1183354841.escalate_after", "14400s"),
-					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.1183354841.escalate_to", "/contact_group/4661"),
+					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.1183354841.escalate_to", testAccContactGroup1),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.2942620849.severity", "5"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.2942620849.reminder", "300s"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.2942620849.escalate_after", "18000s"),
-					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.2942620849.escalate_to", "/contact_group/4661"),
+					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "alert_option.2942620849.escalate_to", testAccContactGroup1),
 					resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "long_message", "a long message"),
 					resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "long_subject", "long subject"),
 					resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "long_summary", "long summary"),
@@ -206,35 +212,35 @@ resource "circonus_contact_group" "staging-sev3" {
     severity = 1
     reminder = "60s"
     escalate_after = "3600s"
-    escalate_to = "/contact_group/4661"
+    escalate_to = "%s"
   }
 
   alert_option {
     severity = 2
     reminder = "2m"
     escalate_after = "2h"
-    escalate_to = "/contact_group/4661"
+    escalate_to = "%s"
   }
 
   alert_option {
     severity = 3
     reminder = "3m"
     escalate_after = "3h"
-    escalate_to = "/contact_group/4661"
+    escalate_to = "%s"
   }
 
   alert_option {
     severity = 4
     reminder = "4m"
     escalate_after = "4h"
-    escalate_to = "/contact_group/4661"
+    escalate_to = "%s"
   }
 
   alert_option {
     severity = 5
     reminder = "5m"
     escalate_after = "5h"
-    escalate_to = "/contact_group/4661"
+    escalate_to = "%s"
   }
 */
   // alert_formats: omit to use defaults

--- a/circonus/resource_circonus_graph_test.go
+++ b/circonus/resource_circonus_graph_test.go
@@ -23,7 +23,12 @@ func TestAccCirconusGraph_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusGraph,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusGraphConfigFmt, graphCheckName, graphName, ""),
+				Config: fmt.Sprintf(testAccCirconusGraphConfigFmt,
+					graphCheckName,
+					testAccBroker1,
+					graphName,
+					"",
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_graph.mixed-points", "name", graphName),
 					resource.TestCheckResourceAttr("circonus_graph.mixed-points", "description", "Terraform Test: mixed graph"),
@@ -75,7 +80,12 @@ func TestAccCirconusGraph_basic(t *testing.T) {
 				),
 			},
 			{ // force modification of graph description, test updating the graph
-				Config: fmt.Sprintf(testAccCirconusGraphConfigFmt, graphCheckName, graphName, " foo"),
+				Config: fmt.Sprintf(testAccCirconusGraphConfigFmt,
+					graphCheckName,
+					testAccBroker1,
+					graphName,
+					" foo",
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_graph.mixed-points", "name", graphName),
 					resource.TestCheckResourceAttr("circonus_graph.mixed-points", "description", "Terraform Test: mixed graph foo"),
@@ -182,7 +192,7 @@ resource "circonus_check" "api_latency" {
   period = "60s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   icmp_ping {

--- a/circonus/resource_circonus_maintenance_test.go
+++ b/circonus/resource_circonus_maintenance_test.go
@@ -26,7 +26,7 @@ func TestAccCirconusMaintenance_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusMaintenance,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusMaintenanceConfigFmt, checkName, startTime, stopTime),
+				Config: fmt.Sprintf(testAccCirconusMaintenanceConfigFmt, checkName, testAccBroker1, startTime, stopTime),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("circonus_maintenance.check-maintenance", "check"),
 					resource.TestCheckResourceAttr("circonus_maintenance.check-maintenance", "start", startTime),
@@ -84,14 +84,14 @@ func checkMaintenanceExists(c *providerContext, maintenanceCID api.CIDType) (boo
 	return false, nil
 }
 
-const testAccCirconusMaintenanceConfigFmt = `
+var testAccCirconusMaintenanceConfigFmt = `
 resource "circonus_check" "api_latency" {
   active = true
   name = "%s"
   period = "60s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   icmp_ping {

--- a/circonus/resource_circonus_rule_set_group_test.go
+++ b/circonus/resource_circonus_rule_set_group_test.go
@@ -20,7 +20,26 @@ func TestAccCirconusRuleSetGroup_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusRuleSetGroup,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusRuleSetGroupConfigFmt, rulesetGroupCheckName),
+				Config: fmt.Sprintf(testAccCirconusRuleSetGroupConfigFmt,
+					rulesetGroupCheckName,
+					testAccBroker1,
+					testAccContactGroup3,
+					testAccContactGroup2,
+					testAccContactGroup2,
+					testAccContactGroup2,
+					testAccContactGroup2,
+					testAccContactGroup3,
+					testAccContactGroup2,
+					testAccContactGroup3,
+					testAccContactGroup3,
+					testAccContactGroup3,
+					testAccContactGroup3,
+					testAccContactGroup3,
+					testAccContactGroup3,
+					testAccContactGroup3,
+					testAccContactGroup3,
+					testAccContactGroup3,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("circonus_rule_set.icmp_max_latency", "check"),
 					resource.TestCheckResourceAttr("circonus_rule_set.icmp_max_latency", "metric_name", "maximum"),
@@ -117,7 +136,7 @@ resource "circonus_check" "api_latency" {
   period = "60s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   icmp_ping {
@@ -155,8 +174,8 @@ resource "circonus_rule_set" "icmp_max_latency" {
 
     then {
       notify = [
-        "/contact_group/4680",
-        "/contact_group/4679"
+        "%s",
+        "%s"
       ]
       severity = 1
     }
@@ -173,7 +192,7 @@ resource "circonus_rule_set" "icmp_max_latency" {
     }
 
     then {
-      notify = [ "/contact_group/4679" ]
+      notify = [ "%s" ]
       severity = 2
     }
   }
@@ -190,7 +209,7 @@ resource "circonus_rule_set" "icmp_max_latency" {
     }
 
     then {
-      notify = [ "/contact_group/4679" ]
+      notify = [ "%s" ]
       severity = 3
     }
   }
@@ -201,7 +220,7 @@ resource "circonus_rule_set" "icmp_max_latency" {
     }
 
     then {
-      notify = [ "/contact_group/4679" ]
+      notify = [ "%s" ]
       after = "2400"
       severity = 4
     }
@@ -248,8 +267,8 @@ resource "circonus_rule_set" "icmp_min_latency" {
 
     then {
       notify = [
-        "/contact_group/4680",
-        "/contact_group/4679"
+        "%s",
+        "%s"
       ]
       severity = 3
     }
@@ -268,7 +287,7 @@ resource "circonus_rule_set" "icmp_avg_latency" {
     then {
       severity = 1
       notify = [
-        "/contact_group/4680",
+        "%s",
       ]
     }
   }
@@ -279,7 +298,7 @@ resource "circonus_rule_set" "icmp_avg_latency" {
     then {
       severity = 3
       notify = [
-        "/contact_group/4680",
+        "%s",
       ]
     }
   }
@@ -294,7 +313,7 @@ resource "circonus_rule_set" "icmp_avg_latency" {
     }
     then {
       notify = [
-        "/contact_group/4680",
+        "%s",
       ]
       severity = 2
     }
@@ -306,13 +325,13 @@ resource "circonus_rule_set_group" "icmp_latency_1" {
 
   notify {
     sev1 = [
-      "/contact_group/4680"
+      "%s"
     ]
     sev2 = [
-      "/contact_group/4680"
+      "%s"
     ]
     sev3 = [
-      "/contact_group/4680"
+      "%s"
     ]
   }
 
@@ -347,13 +366,13 @@ resource "circonus_rule_set_group" "icmp_latency_2" {
 
   notify {
     sev1 = [
-      "/contact_group/4680"
+      "%s"
     ]
     sev2 = [
-      "/contact_group/4680"
+      "%s"
     ]
     sev3 = [
-      "/contact_group/4680"
+      "%s"
     ]
   }
 

--- a/circonus/resource_circonus_rule_set_test.go
+++ b/circonus/resource_circonus_rule_set_test.go
@@ -20,7 +20,20 @@ func TestAccCirconusRuleSet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusRuleSet,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusRuleSetConfigFmt, rulesetCheckName),
+				Config: fmt.Sprintf(testAccCirconusRuleSetConfigFmt,
+					rulesetCheckName,
+					testAccBroker1,
+					testAccContactGroup3,
+					testAccContactGroup2,
+					testAccContactGroup2,
+					testAccContactGroup2,
+					testAccContactGroup2,
+					testAccContactGroup3,
+					testAccContactGroup2,
+					testAccContactGroup3,
+					testAccContactGroup3,
+					testAccContactGroup3,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("circonus_rule_set.icmp-latency-alarm", "check"),
 					resource.TestCheckResourceAttr("circonus_rule_set.icmp-latency-alarm", "metric_name", "maximum"),
@@ -87,7 +100,13 @@ func TestAccCirconusRuleSet_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: fmt.Sprintf(testAccCirconusRuleSetConfigUpdateFmt, rulesetCheckName),
+				Config: fmt.Sprintf(testAccCirconusRuleSetConfigUpdateFmt,
+					rulesetCheckName,
+					testAccBroker1,
+					testAccContactGroup3,
+					testAccContactGroup3,
+					testAccContactGroup3,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("circonus_rule_set.circ-6825", "check"),
 					resource.TestCheckResourceAttr("circonus_rule_set.circ-6825", "metric_name", "average"),
@@ -176,7 +195,7 @@ resource "circonus_check" "api_latency" {
   period = "60s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   icmp_ping {
@@ -224,8 +243,8 @@ EOF
 
     then {
       notify = [
-        "/contact_group/4680",
-        "/contact_group/4679"
+        "%s",
+        "%s"
       ]
       severity = 1
     }
@@ -242,7 +261,7 @@ EOF
     }
 
     then {
-      notify = [ "/contact_group/4679" ]
+      notify = [ "%s" ]
       severity = 2
     }
   }
@@ -259,7 +278,7 @@ EOF
     }
 
     then {
-      notify = [ "/contact_group/4679" ]
+      notify = [ "%s" ]
       severity = 3
     }
   }
@@ -270,7 +289,7 @@ EOF
     }
 
     then {
-      notify = [ "/contact_group/4679" ]
+      notify = [ "%s" ]
       after = "2400"
       severity = 4
     }
@@ -320,8 +339,8 @@ EOF
 
     then {
       notify = [
-        "/contact_group/4680",
-        "/contact_group/4679"
+        "%s",
+        "%s"
       ]
       severity = 1
     }
@@ -342,7 +361,7 @@ EOF
     then {
       severity = 1
       notify = [
-        "/contact_group/4680",
+        "%s",
       ]
     }
   }
@@ -353,7 +372,7 @@ EOF
     then {
       severity = 4
       notify = [
-        "/contact_group/4680",
+        "%s",
       ]
     }
   }
@@ -368,7 +387,7 @@ EOF
     }
     then {
       notify = [
-        "/contact_group/4680",
+        "%s",
       ]
       severity = 2
     }
@@ -388,7 +407,7 @@ resource "circonus_check" "api_latency" {
   period = "60s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   icmp_ping {
@@ -428,7 +447,7 @@ EOF
     then {
       severity = 1
       notify = [
-        "/contact_group/4680",
+        "%s",
       ]
     }
   }
@@ -439,7 +458,7 @@ EOF
     then {
       severity = 4
       notify = [
-        "/contact_group/4680",
+        "%s",
       ]
     }
   }
@@ -454,7 +473,7 @@ EOF
     }
     then {
       notify = [
-        "/contact_group/4680",
+        "%s",
       ]
       severity = 2
     }

--- a/circonus/resource_circonus_worksheet_test.go
+++ b/circonus/resource_circonus_worksheet_test.go
@@ -22,7 +22,12 @@ func TestAccCirconusWorksheet_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDestroyCirconusWorksheet,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(testAccCirconusWorksheetConfigFmt, checkName, graphName, worksheetName),
+				Config: fmt.Sprintf(testAccCirconusWorksheetConfigFmt,
+					checkName,
+					testAccBroker1,
+					graphName,
+					worksheetName,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("circonus_worksheet.test", "favorite"),
 				),
@@ -83,7 +88,7 @@ resource "circonus_check" "api_latency_2" {
   period = "60s"
 
   collector {
-    id = "/broker/1"
+    id = "%s"
   }
 
   icmp_ping {


### PR DESCRIPTION
* upd: This change replaces hardcoded CID's for resources in the acceptance tests with configurable values that can be set using environment variables. This is to allow for execution of the acceptance tests in other environments.