### PR TITLE
CIRC-8532: Remove unsupported external contact methods from the contact group resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.12.10 (June 8, 2022)
+
+CHANGES:
+
+* upd: Removes support from the circonus_contact_group resource for external
+contact methods that are no longer supported: irc and xmpp. Updates the
+documentation to remove these methods as well.
+
 ## 0.12.9 (June 6, 2022)
 
 CHANGES:

--- a/circonus/resource_circonus_contact_test.go
+++ b/circonus/resource_circonus_contact_test.go
@@ -50,10 +50,6 @@ func TestAccCirconusContactGroup_basic(t *testing.T) {
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "sms.#", "1"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "sms.1119127802.user", "/user/5469"),
 
-					// xmpp.# will be 0 for user faux user accounts that don't have an
-					// XMPP address setup.
-					resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "xmpp.#", "0"),
-					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "xmpp.1119127802.user", "/user/5469"),
 					resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "victorops.#", "0"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "victorops.#", "1"),
 					// resource.TestCheckResourceAttr("circonus_contact_group.staging-sev3", "victorops.2029434450.api_key", "123"),
@@ -198,12 +194,6 @@ resource "circonus_contact_group" "staging-sev3" {
     warning = 3
   }
 */
-	// Faux user accounts that don't have an XMPP address setup will not return a
-	// valid response in the future.
-  //
-  // xmpp {
-  //   user = "/user/5469"
-  // }
 
   aggregation_window = "1m"
 

--- a/website/docs/r/contact_group.html.markdown
+++ b/website/docs/r/contact_group.html.markdown
@@ -64,10 +64,6 @@ resource "circonus_contact_group" "myteam-alerts" {
     warning = 3
   }
 
-  xmpp {
-    user = "/user/9876"
-  }
-
   aggregation_window = "5m"
 
   alert_option {
@@ -175,7 +171,7 @@ mechanisms).
 
 ## Supported Contact Group `http` Attributes
 
-* `address` - (Required) URL to send a webhook request to.
+* `url` - (Required) URL to send a webhook request to.
 
 * `format` - (Optional) The payload of the request is a JSON-encoded payload
   when the `format` is set to `json` (the default).  The alternate payload
@@ -183,11 +179,6 @@ mechanisms).
 
 * `method` - (Optional) The HTTP verb to use when making a request.  Either
   `GET` or `POST` may be specified. The default verb is `POST`.
-
-## Supported Contact Group `irc` Attributes
-
-* `user` - (Required) When a user has configured IRC on their user account, they
-  will receive an IRC notification.
 
 ## Supported Contact Group `pager_duty` Attributes
 
@@ -248,15 +239,6 @@ mechanisms).
 * `info` - (Required)
 * `team` - (Required)
 * `warning` - (Required)
-
-## Supported Contact Group `xmpp` Attributes
-
-Either an `address` or `user` attribute is required.
-
-* `address` - (Optional) XMPP address to send a short notification to.
-
-* `user` - (Optional) An XMPP notification will be sent to the XMPP address of
-  record for the corresponding user ID (e.g. `/user/1234`).
 
 ## Import Example
 


### PR DESCRIPTION
CHANGES:

* upd: Removes support from the circonus_contact_group resource for external contact methods that are no longer supported: irc and xmpp. Updates the documentation to remove these methods as well.
* upd: Updates the documentation for the http external contact method to use the field name `url` instead of `address` since address is no longer used.