### PR TITLE
fix(CIRC-10300): Ensure SNMP check OID settings do not swap places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 CHANGES:
 
-* feat(CIRC-10300): Change the type of the OID configurations for SNMP checks
+* fix(CIRC-10300): Change the type of the OID configurations for SNMP checks
 from TypeList to TypeSet. This ensures the state is always ordered the same
 regardless of how the API returns the configuration keys. This should resolve
 issues of OID's changing positions in the state when applying SNMP checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.12.15 (May 25, 2023)
+
+CHANGES:
+
+* feat(CIRC-10300): Change the type of the OID configurations for SNMP checks
+from TypeList to TypeSet. This ensures the state is always ordered the same
+regardless of how the API returns the configuration keys. This should resolve
+issues of OID's changing positions in the state when applying SNMP checks.
+
 ## 0.12.14 (December 6, 2022)
 
 CHANGES:

--- a/circonus/resource_circonus_check_snmp_test.go
+++ b/circonus/resource_circonus_check_snmp_test.go
@@ -70,16 +70,16 @@ resource "circonus_check" "snmp" {
     security_level = "authNoPriv"
 
     oid {
-      name = "upsBatCapacity"
-      path = ".1.3.6.1.4.1.318.1.1.1.2.2.1.0"
+      name = "upsBatVoltage"
+      path = ".1.3.6.1.4.1.318.1.1.1.2.2.8.0"
     }
     oid {
       name = "upsBatTimeRemaining"
       path = ".1.3.6.1.4.1.318.1.1.1.2.2.3.0"
     }
     oid {
-      name = "upsBatVoltage"
-      path = ".1.3.6.1.4.1.318.1.1.1.2.2.8.0"
+      name = "upsBatCapacity"
+      path = ".1.3.6.1.4.1.318.1.1.1.2.2.1.0"
     }
   }
 


### PR DESCRIPTION
Change the type of the OID configurations for SNMP checks to use TypeSet, rather than TypeList. This ensures that the state is always ordered in the same way, regardless of how the API returns the configuration keys.

This should resolve the issue of OID's changing positions in the state when applying SNMP checks.